### PR TITLE
Zype UserAgent Builder (replacing UIWebView reflection)

### DIFF
--- a/ZypeAppleTVBase.xcodeproj/project.pbxproj
+++ b/ZypeAppleTVBase.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0B4EAD8FE9EA3273FF6B8E8D /* Pods_ZypeAppleTVBase.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 068DE8B2673B2EA0EC3BAB89 /* Pods_ZypeAppleTVBase.framework */; };
 		478A52851F210DBC0037BE56 /* RegisterVC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 478A52841F210DBC0037BE56 /* RegisterVC.swift */; };
+		4F37FFD2244F442400D24986 /* ZypeUserAgentBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F37FFD1244F442400D24986 /* ZypeUserAgentBuilder.swift */; };
 		4FD21C552449EC8000E2616B /* GuideModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD21C532449EC8000E2616B /* GuideModel.swift */; };
 		4FD21C562449EC8000E2616B /* GuideProgramModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4FD21C542449EC8000E2616B /* GuideProgramModel.swift */; };
 		78179C2E7ADDA5888C760795 /* Pods_ZypeAppleTVBaseTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = AA67D6B7859F874CF02D4956 /* Pods_ZypeAppleTVBaseTests.framework */; };
@@ -91,6 +92,7 @@
 		44104F0975F4A39966F0703E /* Pods-ZypeAppleTVBaseTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZypeAppleTVBaseTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-ZypeAppleTVBaseTests/Pods-ZypeAppleTVBaseTests.release.xcconfig"; sourceTree = "<group>"; };
 		478A52841F210DBC0037BE56 /* RegisterVC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RegisterVC.swift; sourceTree = "<group>"; };
 		4DF2A3FD2DC74F67C966B8C9 /* Pods-ZypeAppleTVBaseTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-ZypeAppleTVBaseTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-ZypeAppleTVBaseTests/Pods-ZypeAppleTVBaseTests.debug.xcconfig"; sourceTree = "<group>"; };
+		4F37FFD1244F442400D24986 /* ZypeUserAgentBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZypeUserAgentBuilder.swift; sourceTree = "<group>"; };
 		4FD21C532449EC8000E2616B /* GuideModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuideModel.swift; sourceTree = "<group>"; };
 		4FD21C542449EC8000E2616B /* GuideProgramModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuideProgramModel.swift; sourceTree = "<group>"; };
 		A11F0F541D4A55DF00166479 /* ZypeAppleTVBaseResources.bundle */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ZypeAppleTVBaseResources.bundle; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -299,6 +301,7 @@
 			isa = PBXGroup;
 			children = (
 				A11F0FA71D4A5E5300166479 /* ZypeAppSettings.swift */,
+				4F37FFD1244F442400D24986 /* ZypeUserAgentBuilder.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -647,6 +650,7 @@
 				A11F0FE31D4A5E5300166479 /* QueryZobjectsModel.swift in Sources */,
 				A11F0FD91D4A5E5300166479 /* ZypeDataManager.swift in Sources */,
 				A11F0FE41D4A5E5300166479 /* QueryZobjectTypesModel.swift in Sources */,
+				4F37FFD2244F442400D24986 /* ZypeUserAgentBuilder.swift in Sources */,
 				A11F0FE01D4A5E5300166479 /* QueryRetrieveVideosInPlaylistModel.swift in Sources */,
 				A11F0FE21D4A5E5300166479 /* QueryVideosModel.swift in Sources */,
 				A11F0FDA1D4A5E5300166479 /* ZypeTokenManager.swift in Sources */,

--- a/ZypeAppleTVBase/Factories/VimeoUrl.swift
+++ b/ZypeAppleTVBase/Factories/VimeoUrl.swift
@@ -20,11 +20,7 @@ class VimeoUrl: BaseUrl, VideoUrl {
     }
     
     func sysUserAgent() ->  String? {
-        let webViewClass: AnyObject.Type = NSClassFromString("UIWebView")!
-        let webViewObject: NSObject.Type = webViewClass as! NSObject.Type
-        let webView: AnyObject = webViewObject.init()
-        let userAgent = webView.stringByEvaluatingJavaScript(from: "navigator.userAgent")
-        return userAgent
+        return ZypeUserAgentBuilder.buildtUserAgent().userAgent()
     }
     
     func userAgent() ->  String? {
@@ -41,13 +37,9 @@ class VimeoUrl: BaseUrl, VideoUrl {
             else if var sysAgent = sysAgent, let range = sysAgent.range(of:"Apple TV;"), let appName = appName, let version = version {
                 sysAgent.replaceSubrange(range, with: "\(machine);")
                 user_agent = "\(sysAgent) \(appName)/\(version)"
+            } else {
+                user_agent = sysAgent
             }
-            #if os(tvOS)
-            if var user_agent_temp = user_agent, let range = user_agent_temp.range(of:"iPhone OS") {
-                user_agent_temp.replaceSubrange(range, with: "\(UIDevice.current.systemName)")
-                user_agent = user_agent_temp
-            }
-            #endif
         }
         return user_agent
     }

--- a/ZypeAppleTVBase/Helpers/ZypeUserAgentBuilder.swift
+++ b/ZypeAppleTVBase/Helpers/ZypeUserAgentBuilder.swift
@@ -1,0 +1,58 @@
+//
+//  ZypeUserAgentBuilder.swift
+//  ZypeAppleTVBase
+//
+//  Created by Anish Kumar on 21/04/20.
+//  Copyright © 2020 Zype. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+struct UserAgent {
+    public static let product = "Mozilla/5.0"
+    public static let platform = "AppleWebKit/605.1.15"
+    public static let platformDetails = "(KHTML, like Gecko)"
+    public static let uaBitMobile = "Mobile/15E148"
+}
+
+public struct ZypeUserAgentBuilder {
+    // User agent components
+    fileprivate var product: String
+    fileprivate var systemInfo: String
+    fileprivate var platform: String
+    fileprivate var platformDetails: String
+    fileprivate var appVersion: String
+    fileprivate var uaBitMobile: String
+
+    init(product: String, systemInfo: String, platform: String, platformDetails: String, uaBitMobile: String, appVersion: String) {
+        self.product = product
+        self.systemInfo = systemInfo
+        self.platform = platform
+        self.platformDetails = platformDetails
+        self.uaBitMobile = uaBitMobile
+        self.appVersion = appVersion
+    }
+    
+    public func userAgent() -> String {
+        let userAgentItems = [product, systemInfo, platform, platformDetails, uaBitMobile, appVersion]
+        return removeEmptyComponentsAndJoin(uaItems: userAgentItems)
+    }
+    
+    public static func buildtUserAgent() -> ZypeUserAgentBuilder {
+        return ZypeUserAgentBuilder(product: UserAgent.product, systemInfo: "(\(UIDevice.current.model.replacingOccurrences(of: " ", with: "")),3; CPU tvOS \(UIDevice.current.systemVersion.replacingOccurrences(of: ".", with: "_")) like Mac OS X)", platform: UserAgent.platform, platformDetails: UserAgent.platformDetails, uaBitMobile: UserAgent.uaBitMobile, appVersion: ZypeUserAgentBuilder.appNameAndVersion())
+    }
+
+    /// Helper method to remove the empty components from user agent string that contain only whitespaces or are just empty
+    private func removeEmptyComponentsAndJoin(uaItems: [String]) -> String {
+        return uaItems.filter{ !$0.isEmpty }.joined(separator: " ")
+    }
+    
+    //eg. MyApp/1
+    private static func appNameAndVersion() -> String {
+        let dictionary = Bundle.main.infoDictionary!
+        let version = dictionary["CFBundleShortVersionString"] as! String
+        let name = dictionary["CFBundleName"] as! String
+        return "\(name)/\(version)"
+    }
+}


### PR DESCRIPTION
Before -> Mozilla/5.0 (AppleTV5,3; CPU tvOS 10_2_2 like Mac OS X) AppleWebKit/1 (KHTML, like Gecko) Mobile/14W756 zype/1.0

After -> Mozilla/5.0 (AppleTV,3; CPU tvOS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Zype/1.0
